### PR TITLE
linux_6_12: 6.12.22 -> 6.12.85

### DIFF
--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -24,8 +24,8 @@
         "hash": "sha256:1iks6msk4cajyy0khyhrwsdl123hr81n67xzdnhlgg6dvb1famw9"
     },
     "6.12": {
-        "version": "6.12.23",
-        "hash": "sha256:0jbps9sr4bpg4ym6vjib33lfjqjh09azh39ck7v7zsyyz0259nfq"
+        "version": "6.12.85",
+        "hash": "sha256-41rJmfQKaHRJPY1g8z8RUNeomuWEHEKNqCJX+80HCu0="
     },
     "6.13": {
         "version": "6.13.11",


### PR DESCRIPTION
to pick up for CVE-2026-31431 (copy.fail)