### PR TITLE
Change default of `enableObjectDeterminism` to `false`

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -205,7 +205,7 @@ in
   coreSetup ? false, # Use only core packages to build Setup.hs.
   useCpphs ? false,
   hardeningDisable ? null,
-  enableObjectDeterminism ? lib.versionAtLeast ghc.version "9.12",
+  enableObjectDeterminism ? false,
   enableSeparateBinOutput ? false,
   enableSeparateDataOutput ? false,
   enableSeparateDocOutput ? doHaddock,


### PR DESCRIPTION
it can cause GHC 9.12 to panic
 reenable once the flag is no longer experimental.