### PR TITLE
nixos/postgresql: fix upgrade script for systemd 259

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -194,11 +194,13 @@ let
       timer_pid="$!"
 
       pushd "${cfg.dataDir}"
-      ${cfg.finalPackage}/bin/pg_upgrade ${lib.cli.toCommandLineShellGNU { } args} ${lib.escapeShellArgs cfg.upgrade.extraArgs}
+      # Unset NOTIFY_SOCKET so that postgres instances spawned internally by pg_upgrade
+      # do not send READY=1 to systemd, which would prevent the real ExecStart from notifying.
+      env -u NOTIFY_SOCKET ${cfg.finalPackage}/bin/pg_upgrade ${lib.cli.toCommandLineShellGNU { } args} ${lib.escapeShellArgs cfg.upgrade.extraArgs}
       touch .post_upgrade
 
       # Restore timeout consumed by upgrade
-      kill $timer_pid
+      kill "$timer_pid"
       ${lib.getExe' pkgs.systemd "systemd-notify"} --status="" EXTEND_TIMEOUT_USEC=120000000
     '';
   };

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -181,11 +181,16 @@ let
         exit 0
       fi
 
-      while true; do
-        echo "Extending systemd timeout to 2 minutes from now while upgrade is running"
-        ${lib.getExe' pkgs.systemd "systemd-notify"} --status="Running major version upgrade" EXTEND_TIMEOUT_USEC=120000000
-        sleep 60
-      done &
+      # Track the sleep PID so the SIGTERM trap can kill it explicitly.
+      # Without this, killing the subshell leaves the sleep child as an orphan in the cgroup.
+      ( trap 'kill "$sleep_pid" 2>/dev/null; exit' TERM
+        while true; do
+          echo "Extending systemd timeout to 2 minutes from now while upgrade is running"
+          ${lib.getExe' pkgs.systemd "systemd-notify"} --status="Running major version upgrade" EXTEND_TIMEOUT_USEC=120000000
+          sleep 60 &
+          sleep_pid=$!
+          wait "$sleep_pid"
+        done ) &
       timer_pid="$!"
 
       pushd "${cfg.dataDir}"


### PR DESCRIPTION
## Summary

Two bugs in the `pg_upgrade` wrapper script surfaced after upgrading to systemd 259:

**1. Leftover `sleep` process in cgroup**

The timer loop used to extend the startup timeout ran `sleep 60` in the
foreground of a background subshell. Killing the subshell with `kill $timer_pid`
left the already-forked `sleep` as an orphan in the service's cgroup. Newer
systemd warns about leftover cgroup members on service start, which obscured
the real failure described below.

Fixed by tracking `sleep_pid` explicitly and killing it in a `SIGTERM` trap on
the subshell, using `wait $!` so the trap fires immediately rather than after the
sleep finishes.

**2. `pg_upgrade` internal postgres instances sending `READY=1` to systemd**

`pg_upgrade` starts temporary postgres instances internally to read/write catalog
data. Those processes inherit `NOTIFY_SOCKET` from the service environment and
send `sd_notify("READY=1")` while still in `ExecStartPre`. In systemd 259 this
poisons the service's notify state, causing the real `ExecStart` postgres to have
its `READY=1` ignored, which makes the service time out.

Fixed by running `pg_upgrade` under `env -u NOTIFY_SOCKET`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
