### PR TITLE
openssh: 9.9p2 -> 10.4p1

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -7,50 +7,77 @@
 }:
 let
   common = opts: callPackage (import ./common.nix opts) { };
+
+  # Gets the OpenSSH mirror URL.
+  urlFor = version: "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
 in
 {
   openssh = common rec {
     pname = "openssh";
-    version = "9.9p2";
+    version = "10.4p1";
 
     src = fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      hash = "sha256-karbYD4IzChe3fll4RmdAlhfqU2ZTWyuW0Hhch4hVnM=";
+      url = urlFor version;
+      hash = "sha256-72Am3SrqjVYFljjV0yYpAsiSzrqfiDlYNeDQbT+2Mjg=";
     };
 
-    extraPatches = [ ./ssh-keysign-8.5.patch ];
-    extraMeta.maintainers = lib.teams.helsinki-systems.members ++ [ lib.maintainers.philiptaron ];
+    extraPatches = [
+      # Use ssh-keysign from PATH
+      # ssh-keysign is used for host-based authentication, and is designed to be used
+      # as SUID-root program. OpenSSH defaults to referencing it from libexec, which
+      # cannot be made SUID in Nix.
+      ./ssh-keysign-8.5.patch
+    ];
+    extraMeta = {
+      maintainers = with lib.maintainers; [
+        das_j
+        helsinki-Jo
+        numinit
+        philiptaron
+      ];
+    };
   };
 
   openssh_hpn = common rec {
     pname = "openssh-with-hpn";
-    version = "9.9p2";
+    version = "10.3p1";
     extraDesc = " with high performance networking patches";
 
     src = fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      hash = "sha256-karbYD4IzChe3fll4RmdAlhfqU2ZTWyuW0Hhch4hVnM=";
+      url = urlFor version;
+      hash = "sha256-VmgqNruS3PS08Bb9jsjnQFm3mo3iXBXWcNcx59GORfQ=";
     };
 
     extraPatches =
       let
-        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/7ba88c964b6e5724eec462021d984da3989e6a08/security/openssh-portable/files/extra-patch-hpn";
+        urlBase = "https://raw.githubusercontent.com/freebsd/freebsd-ports/294be7ad9ef5106b696d830e06b9f322bd79d6f5/security/openssh-portable/files";
+        noBlocklistdHpnGluePatch = "${urlBase}/extra-patch-no-blocklistd-hpn-glue";
+        hpnPatch = "${urlBase}/extra-patch-hpn";
       in
       [
         ./ssh-keysign-8.5.patch
 
+        # the blocklistd patch from FreeBSD ports is now required for HPN,
+        # unless we apply this HPN glue patch
+        (fetchpatch {
+          name = "ssh-no-blocklistd-hpn-glue.patch";
+          url = noBlocklistdHpnGluePatch;
+          extraPrefix = "";
+          hash = "sha256-+AeJ9fLmmT/P07JZvGaXpNft+2F9PoFsbzr+s9wfdro=";
+        })
+
         # HPN Patch from FreeBSD ports
         (fetchpatch {
           name = "ssh-hpn-wo-channels.patch";
-          inherit url;
+          url = hpnPatch;
           stripLen = 1;
           excludes = [ "channels.c" ];
-          hash = "sha256-zk7t6FNzTE+8aDU4QuteR1x0W3O2gjIQmeCkTNbaUfA=";
+          hash = "sha256-dEYCSBcUXbSBzoMV/6QwLl5tj0c0/DPTtArchfRRQvM=";
         })
 
         (fetchpatch {
           name = "ssh-hpn-channels.patch";
-          inherit url;
+          url = hpnPatch;
           extraPrefix = "";
           includes = [ "channels.c" ];
           hash = "sha256-pDLUbjv5XIyByEbiRAXC3WMUPKmn15af1stVmcvr7fE=";
@@ -67,21 +94,27 @@ in
 
   openssh_gssapi = common rec {
     pname = "openssh-with-gssapi";
-    version = "9.9p2";
+    version = "10.4p1";
     extraDesc = " with GSSAPI support";
 
     src = fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      hash = "sha256-karbYD4IzChe3fll4RmdAlhfqU2ZTWyuW0Hhch4hVnM=";
+      url = urlFor version;
+      hash = "sha256-72Am3SrqjVYFljjV0yYpAsiSzrqfiDlYNeDQbT+2Mjg=";
     };
 
     extraPatches = [
       ./ssh-keysign-8.5.patch
 
       (fetchpatch {
-        name = "openssh-gssapi.patch";
-        url = "https://salsa.debian.org/ssh-team/openssh/raw/debian/1%25${version}-1/debian/patches/gssapi.patch";
-        hash = "sha256-JyOXA8Al8IFLdndJQ1LO+r4hJqtXjz1NHwOPiSAQkE8=";
+        name = "servconf-fix-gssapi.patch";
+        url = "https://salsa.debian.org/ssh-team/openssh/raw/debian/1%2510.4p1-1/debian/patches/servconf-fix-gssapi.patch";
+        hash = "sha256-ypyaoEhwxo7SYVpjMkCQnrcFgY2ouWJQlrbJy50Lidk=";
+      })
+
+      (fetchpatch {
+        name = "gssapi.patch";
+        url = "https://salsa.debian.org/ssh-team/openssh/raw/debian/1%2510.4p1-1/debian/patches/gssapi.patch";
+        hash = "sha256-K12AE4C0zMdRdMsRMQCMRIFvN+NhNvCgyt0NDZp7n24=";
       })
     ];
 


### PR DESCRIPTION
addresses: CVE-2026-59995, CVE-2026-59996, CVE-2026-60001, and CVE-2026-60002